### PR TITLE
Updated bool for numpy==1.24.3

### DIFF
--- a/incasem/gunpowder/masked_intensity_augment.py
+++ b/incasem/gunpowder/masked_intensity_augment.py
@@ -77,7 +77,7 @@ class MaskedIntensityAugment(BatchFilter):
         scale = np.random.uniform(low=self.scale_min, high=self.scale_max)
         shift = np.random.uniform(low=self.shift_min, high=self.shift_max)
 
-        binary_mask = batch[self.mask].data.astype(np.bool)
+        binary_mask = batch[self.mask].data.astype(bool)
         scale = binary_mask * scale + \
             np.logical_not(binary_mask).astype(raw.data.dtype)
         shift = binary_mask * shift

--- a/incasem/gunpowder/merge_local_shape_descriptors.py
+++ b/incasem/gunpowder/merge_local_shape_descriptors.py
@@ -54,7 +54,7 @@ class MergeLocalShapeDescriptors(gp.BatchFilter):
         elif self.ambiguous == 'background':
             sum_of_binaries = np.sum(
                 np.array(
-                    [np.any(batch[array].data.astype(np.bool), axis=0)
+                    [np.any(batch[array].data.astype(bool), axis=0)
                      for array in self.arrays]
                 ),
                 axis=0
@@ -68,7 +68,7 @@ class MergeLocalShapeDescriptors(gp.BatchFilter):
                 axis=0
             )
 
-            mask = np.any(lsds.astype(np.bool), axis=0)
+            mask = np.any(lsds.astype(bool), axis=0)
 
             not_ambiguous = np.logical_and(
                 mask, np.logical_not(ambiguous))

--- a/incasem/gunpowder/merge_masks.py
+++ b/incasem/gunpowder/merge_masks.py
@@ -36,7 +36,7 @@ class MergeMasks(gp.BatchFilter):
         spec = batch[self.arrays[0]].spec.copy()
 
         mask = np.logical_and.reduce(
-            [batch[key].data.astype(np.bool) for key in self.arrays]
+            [batch[key].data.astype(bool) for key in self.arrays]
         )
 
         mask = mask.astype(np.uint8)

--- a/incasem/metrics/confusion_matrix.py
+++ b/incasem/metrics/confusion_matrix.py
@@ -23,10 +23,10 @@ def confusion_matrix(target, prediction_probas, mask=None):
     start = time.time()
 
     if mask is None:
-        mask = np.ones_like(target, dtype=np.bool)
+        mask = np.ones_like(target, dtype=bool)
         logger.debug("Mask not provided, using default array of ones.")
     else:
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     assert target.shape == mask.shape
 
@@ -47,7 +47,7 @@ def confusion_matrix(target, prediction_probas, mask=None):
 
     if num_classes == 2:
         scores = np.bincount(
-            target.astype(np.bool) * 2 + prediction.astype(np.bool),
+            target.astype(bool) * 2 + prediction.astype(bool),
             minlength=4
         ).reshape(2, 2)
         scores = scores / scores.sum()

--- a/incasem/metrics/jaccard.py
+++ b/incasem/metrics/jaccard.py
@@ -56,10 +56,10 @@ def jaccard(target, prediction_probas, mask=None):
     num_classes = prediction_probas.shape[0]
 
     if mask is None:
-        mask = np.ones_like(target, dtype=np.bool)
+        mask = np.ones_like(target, dtype=bool)
         logger.debug("Mask not provided, using default array of ones.")
     else:
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     assert target.shape == mask.shape
 

--- a/incasem/metrics/pairwise_distance_metric_thresholded.py
+++ b/incasem/metrics/pairwise_distance_metric_thresholded.py
@@ -51,10 +51,10 @@ def pairwise_distance_metric_thresholded(
     assert prediction_probas.min() >= 0.0
 
     if mask is None:
-        mask = np.ones_like(target, dtype=np.bool)
+        mask = np.ones_like(target, dtype=bool)
         logger.debug("Mask not provided, using default array of ones.")
     else:
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     assert target.shape == mask.shape
 

--- a/incasem/metrics/precision_recall.py
+++ b/incasem/metrics/precision_recall.py
@@ -33,10 +33,10 @@ def precision_recall(target, prediction_probas, mask=None, threshold=None):
     assert prediction_probas.min() >= 0.0
 
     if mask is None:
-        mask = np.ones_like(target, dtype=np.bool)
+        mask = np.ones_like(target, dtype=bool)
         logger.debug("Mask not provided, using default array of ones.")
     else:
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     assert target.shape == mask.shape
 

--- a/scripts/04_postprocessing/05_evaluate_metric.py
+++ b/scripts/04_postprocessing/05_evaluate_metric.py
@@ -120,8 +120,8 @@ def evaluate_metric(
         probas = probas * (mask != 0).astype(probas.dtype)
 
         metric_mask = np.logical_and(
-            mask.astype(np.bool),
-            metric_mask.astype(np.bool)
+            mask.astype(bool),
+            metric_mask.astype(bool)
         )
 
     # TODO parallelize, log results to DB


### PR DESCRIPTION
Changed np.bool into bool. Tested by running a dummy training which no longer gave the error about deprecated np.bool support. 