### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ We provide the following pre-trained models:
 - For FIB-SEM data prepared by high-pressure freezing, `4x4x4` nm<sup>3</sup> resolution:
     - Mitochondria (model ID `1675`)
     - Endoplasmic Reticulum (model ID `1669`)
-- For FIB-SEM data prepared by high-pressure freezing, `5x5x5` nm<sup>3</sup> resolution:
     - Clathrin-Coated Pits (model ID `1986`) 
     - Nuclear Pores (model ID `2000`)
 


### PR DESCRIPTION
Choose a model section in prediction has inaccurate information about the resolution for Clathrin-Coated Pits and Nuclear Pores. Originally 5x5x5, actually 4x4x4 as seen in the database for those experiments with the IDs 1986 and 2000. Therefore, we should combine them with the previous bullet point (high pressure freezing and 4x4x4).
![Screenshot 2023-06-05 at 2 29 35 PM](https://github.com/kirchhausenlab/incasem/assets/42418601/5ec272a1-5bf8-47c8-9f1d-d7237196a26d)
![Screenshot 2023-06-05 at 2 30 23 PM](https://github.com/kirchhausenlab/incasem/assets/42418601/4bfc9969-ef3a-4b71-80a9-4baab91dd5d4)
After merge, branch can be deleted.
