### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 ```
 Optional: In case of permission issues, run
 ```bash
-chmod +x Miniconda3-latest-Linux-x86_64.sh`
+chmod +x Miniconda3-latest-Linux-x86_64.sh
 ```
 
 Install anaconda.


### PR DESCRIPTION
An extra back tick was present in the optional permission issue instruction in section 1, installation.